### PR TITLE
fix(tabular_preview): retry once on torn h5ad read; log URL on failure

### DIFF
--- a/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
+++ b/lambdas/tabular_preview/src/t4_lambda_tabular_preview/__init__.py
@@ -335,9 +335,14 @@ def _extract_matrix_preview(adata, *, rows: int = 5, cols: int = 5):
         return None, f"{type(exc).__name__}: {exc}"
 
 
-def _h5ad_error_response(exc: BaseException, telemetry: dict):
+def _h5ad_error_response(exc: BaseException, telemetry: dict, url: str):
     err_type = type(exc).__name__
-    logger.warning("h5ad preview failed: %s: %s", err_type, exc)
+    # Strip presigned-URL query string to keep signatures/credentials out of logs.
+    safe_url = str(url).split("?", 1)[0]
+    logger.warning(
+        "h5ad preview failed: %s: %s (url=%s)",
+        err_type, exc, safe_url,
+    )
     return (
         200,
         b"",
@@ -364,7 +369,39 @@ def _calculate_h5ad_qc_metrics(adata):
     sc.pp.calculate_qc_metrics(adata, percent_top=None, log1p=False, inplace=True)
 
 
+# Errors worth retrying once: torn HTTP reads (OSError from h5py) and
+# transport-level failures from fsspec/aiohttp/urllib. Structural problems
+# (bad h5ad, missing groups) raise ValueError/KeyError and are not retried.
+_H5AD_RETRYABLE = (OSError,)
+
+
 def preview_h5ad(url, compression, max_out_size):
+    last_exc: BaseException | None = None
+    last_counter = None
+    for attempt in range(2):
+        try:
+            return _preview_h5ad_once(url, compression, max_out_size)
+        except _H5AD_RETRYABLE as exc:
+            last_exc = exc
+            last_counter = getattr(exc, "_h5ad_counter", None)
+            logger.warning(
+                "h5ad preview attempt %d failed: %s: %s",
+                attempt + 1, type(exc).__name__, exc,
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 - non-retryable; fall through to error envelope
+            last_exc = exc
+            last_counter = getattr(exc, "_h5ad_counter", None)
+            break
+    telemetry = last_counter.stats() if last_counter is not None else {
+        "range_request_count": 0,
+        "total_bytes_read": 0,
+        "max_single_read": 0,
+    }
+    return _h5ad_error_response(last_exc, telemetry, url)
+
+
+def _preview_h5ad_once(url, compression, max_out_size):
     import anndata
     import h5py
 
@@ -421,13 +458,12 @@ def preview_h5ad(url, compression, max_out_size):
                 }
                 if matrix_preview is None and matrix_preview_error is not None:
                     info["meta"]["matrix_preview_error"] = matrix_preview_error
-    except Exception as exc:  # noqa: BLE001 - catch urlopen + h5py/anndata family
-        telemetry = counter.stats() if counter is not None else {
-            "range_request_count": 0,
-            "total_bytes_read": 0,
-            "max_single_read": 0,
-        }
-        return _h5ad_error_response(exc, telemetry)
+    except Exception as exc:
+        # Attach the counter so the retry/error wrapper can read telemetry
+        # even though the with-block has already torn down `raw_src`.
+        if counter is not None:
+            exc._h5ad_counter = counter  # type: ignore[attr-defined]
+        raise
 
     info["telemetry"] = counter.stats()
 

--- a/lambdas/tabular_preview/tests/test_index.py
+++ b/lambdas/tabular_preview/tests/test_index.py
@@ -274,6 +274,35 @@ def test_preview_h5ad_error_envelope_on_bad_file():
     assert "telemetry" in info
 
 
+def test_preview_h5ad_retries_once_on_oserror(mocker):
+    """A torn HTTP read (OSError from h5py) should retry once and succeed
+    on the second attempt rather than going straight to the error envelope."""
+    real_h5ad = pathlib.Path(__file__).parent / "data" / "simple/test.h5ad"
+    real_bytes = real_h5ad.read_bytes()
+
+    # First attempt: hand h5py a stream that truncates after 512 bytes
+    # (the same signature as the production bug). Second attempt: real file.
+    sources = [
+        io.BytesIO(real_bytes[:512]),
+        io.BytesIO(real_bytes),
+    ]
+    mocker.patch(
+        "t4_lambda_tabular_preview.urlopen",
+        side_effect=lambda *a, **kw: sources.pop(0),
+    )
+
+    code, body, headers = t4_lambda_tabular_preview.handlers["h5ad"](
+        url="https://example.com/x.h5ad?Signature=redacted",
+        compression=None,
+        max_out_size=None,
+    )
+    assert code == 200
+    info = json.loads(headers[QUILT_INFO_HEADER])
+    assert "error" not in info["meta"], info["meta"]
+    assert info["meta"]["n_cells"] >= 1
+    assert sources == []  # both attempts consumed
+
+
 def test_extract_matrix_preview_handles_sparse(mocker):
     """_extract_matrix_preview should densify sparse matrices."""
     import numpy


### PR DESCRIPTION
## Summary

While testing #4858 against `tf-dev-alexion`, the h5ad preview intermittently failed on a 22 KB `test.h5ad` with:

```
h5ad preview failed: OSError: Unable to synchronously open file
(truncated file: eof = 512, sblock->base_addr = 0, stored_eof = 22328)
```

The same URL succeeded on retry from the browser, and a local repro against the same S3 object with the same lambda venv (Python 3.13, same `fsspec`/`aiohttp`/`anndata` versions from `uv.lock`) passed 5/5 times. The failure is non-deterministic — a torn HTTP read mid-transfer that leaves h5py thinking the file ends at byte 512.

## Changes

- **One bounded retry on `OSError`** inside `preview_h5ad`. Structural errors (`ValueError`/`KeyError` from a genuinely malformed h5ad) still fall straight through to the `meta.error` envelope from #4901. Counter is attached to the exception so telemetry survives the with-block teardown.
- **Log the URL on failure** (with `?Signature=...` query string stripped to keep presigned creds out of logs). Currently `_h5ad_error_response` only logs the exception type + message — without the URL you can't distinguish a transient transport hiccup from a file that's actually broken.

The hot path is unchanged on success: `preview_h5ad` just delegates to `_preview_h5ad_once`.

## Test plan

- [x] `pytest lambdas/tabular_preview/tests/` — 14 passed (1 new: `test_preview_h5ad_retries_once_on_oserror` — first urlopen returns a 512-byte truncated stream matching the production signature, second returns the real file; asserts no error envelope and both sources consumed).
- [x] Existing `test_preview_h5ad_error_envelope_on_bad_file` still passes — it now exercises the retry path too (both attempts fail → envelope returned), visible in the captured log `h5ad preview attempt 1 failed: OSError: ...`.

Targets `preview-lambda-shared` (#4858) so it lands as part of that chain.